### PR TITLE
Add support for regular style literals

### DIFF
--- a/assembler/src/cst.rs
+++ b/assembler/src/cst.rs
@@ -275,6 +275,16 @@ impl CstParser {
     fn validate_numeric_immediate<'input, T: Num>(&self, src: Token<'input>) -> Immediate<'input, T> {
         let Token { src: str, span, .. } = src;
         let value = if let Some(str_head) = str.get(..=0) {
+
+            // This is a job for `matches!{ }` but alas; we're at the mercy of
+            // our MSRV.
+            let (str_head, offset) = match str.get(0..2) {
+                Some("0b") | Some("0x") => (str.get(1..2).unwrap(), 2),
+                Some(_) => (str_head, 1),
+                // If we don't have two chars, just pass it along?
+                None => (str_head, 1),
+            };
+
             let radix = match str_head {
                 "b" => Some(2),
                 "#" => Some(10),
@@ -282,7 +292,7 @@ impl CstParser {
                 _ => None
             };
             if let Some(radix) = radix {
-                if let Some(src_tail) = src.src.get(1..) {
+                if let Some(src_tail) = src.src.get(offset..) {
                     T::from_str_radix(src_tail, radix)
                         .map_err(|_| InvalidImmediateReason::Number { actual: src_tail.to_string() })
                 } else {

--- a/assembler/src/cst.rs
+++ b/assembler/src/cst.rs
@@ -437,3 +437,30 @@ impl CstParser {
     }
 }
 
+#[cfg(test)]
+mod immediate_tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn single_test<N: core::fmt::Debug + Num>(num: &str, actual: N)  {
+        let p = CstParser { leniency: LeniencyLevel::Lenient };
+
+        let tok = Token { src: num, span: (0, 0), ty: crate::lexer::TokenType::Ambiguous };
+
+        assert_eq!(actual, p.validate_numeric_immediate(tok).value.unwrap());
+    }
+
+    #[test]
+    fn regular() {
+        single_test("0x123", 0x123);
+        single_test("0x0123", 0x0123);
+        single_test("0b0101", 0b0101);
+    }
+
+    #[test]
+    fn patt_style() {
+        single_test("#100", 100);
+        single_test("x456", 0x456);
+        single_test("b0101", 0b0101);
+    }
+}

--- a/assembler/src/parser.rs
+++ b/assembler/src/parser.rs
@@ -11,6 +11,7 @@ pub fn parse(tokens: Lexer, leniency: LeniencyLevel) -> File {
     CstParser { leniency }.parse_cst(ir3)
 }
 
+// TODO: impl Default?
 pub enum LeniencyLevel {
     Lenient,
     Strict,

--- a/assembler/tests/integ.rs
+++ b/assembler/tests/integ.rs
@@ -67,7 +67,7 @@ fn test(input: &str, orig: usize, expected_mem: &[Word]) {
     let lexer = Lexer::new(input);
     let cst = parse(lexer, Lenient);
 
-    let mem = assemble(cst.objects);
+    let mem = assemble(cst.objects, None);
     for i in 0..orig {
         assert_eq!(0x0000, mem[i], "differed at {:#x}", i)
     }


### PR DESCRIPTION
`0x123` and `0b11101`, like the rest of the world.

A few things:
  - I'm almost sure there's a better way to do this than the way I did; feel free to scrap it.
  - Not sure if we should be supporting `#0x123` instead of `0x123`; ditto with `0b111`.
  - There's probably a better way to write the tests too; I didn't poke around enough to actually understand things, sorry.
  - This should maybe be gated on the lenient mode but I wasn't just which mode was the default so I didn't do this.

Thanks!